### PR TITLE
Add Litellm proxy deployment

### DIFF
--- a/apps/litellm-proxy/base/configmap.yaml
+++ b/apps/litellm-proxy/base/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litellm-config
+  namespace: litellm-proxy
+data:
+  config.yaml: |
+    model_list:
+      - model_name: gpt-3.5-turbo
+        litellm_params:
+          model: openai/gpt-3.5-turbo
+          api_base: http://192.168.1.2:1234

--- a/apps/litellm-proxy/base/deployment.yaml
+++ b/apps/litellm-proxy/base/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: litellm-proxy
+  namespace: litellm-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: litellm-proxy}
+  template:
+    metadata:
+      labels: {app: litellm-proxy}
+    spec:
+      containers:
+      - name: proxy
+        image: ghcr.io/berriai/litellm:main-stable
+        args: ["--config", "/etc/litellm/config.yaml"]
+        ports:
+        - containerPort: 4000
+        volumeMounts:
+        - name: config
+          mountPath: /etc/litellm
+      volumes:
+      - name: config
+        configMap:
+          name: litellm-config

--- a/apps/litellm-proxy/base/ingress.yaml
+++ b/apps/litellm-proxy/base/ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: litellm-proxy
+  namespace: litellm-proxy
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-dns
+spec:
+  rules:
+  - host: llm.infrazone.cc
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: litellm-proxy
+            port:
+              number: 80
+  tls:
+  - hosts: [llm.infrazone.cc]
+    secretName: litellm-proxy-tls

--- a/apps/litellm-proxy/base/kustomization.yaml
+++ b/apps/litellm-proxy/base/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/apps/litellm-proxy/base/namespace.yaml
+++ b/apps/litellm-proxy/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: litellm-proxy

--- a/apps/litellm-proxy/base/service.yaml
+++ b/apps/litellm-proxy/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: litellm-proxy
+  namespace: litellm-proxy
+spec:
+  ports:
+  - port: 80
+    targetPort: 4000
+  selector: {app: litellm-proxy}
+  type: ClusterIP

--- a/argocd/litellm-proxy/litellm-proxy.yaml
+++ b/argocd/litellm-proxy/litellm-proxy.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: litellm-proxy
+  namespace: argocd
+spec:
+  source:
+    repoURL: https://github.com/syscall00/declarative-cluster.git
+    targetRevision: HEAD
+    path: apps/litellm-proxy/base
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: litellm-proxy
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary
- add Litellm proxy deployment and service
- expose ingress for llm.infrazone.cc
- wire new application through ArgoCD
- switch to config-based setup

## Testing
- `pip install litellm`
- `litellm --help`


------
https://chatgpt.com/codex/tasks/task_b_685c6db28978832e9e4c456212f87bfa